### PR TITLE
Standardize error message formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   User.parse(id: "123")                              # ✓ valid (name is optional)
   ```
 
+### Changed
+
+- Standardize error messages to use lowercase for consistency with Ruby conventions
+- Improve type error messages to include attribute name for easier debugging
+
 ## [4.1.0] - 2025-10-09
 
 ### Added

--- a/lib/structure/builder.rb
+++ b/lib/structure/builder.rb
@@ -46,7 +46,7 @@ module Structure
       @non_nullable.add(name) unless null
 
       if type && block
-        raise ArgumentError, "Cannot specify both type and block for :#{name}"
+        raise ArgumentError, "cannot specify both type and block for :#{name}"
       else
         types[name] = type || block
       end
@@ -102,7 +102,12 @@ module Structure
 
     # @api private
     def coercions(context = nil)
-      @types.transform_values { |type| Types.coerce(type, context) }
+      @types.to_h do |attr, type|
+        coercion = Types.coerce(type, context)
+        [attr, coercion]
+      rescue ArgumentError => e
+        raise ArgumentError, "#{e.message} for :#{attr}"
+      end
     end
 
     # @api private

--- a/lib/structure/types.rb
+++ b/lib/structure/types.rb
@@ -60,7 +60,7 @@ module Structure
         when String
           lazy_class(type, context)
         else
-          raise ArgumentError, "Cannot specify #{type.inspect} as type"
+          raise ArgumentError, "cannot specify #{type.inspect} as type"
         end
       end
 

--- a/test/test_core_structure.rb
+++ b/test/test_core_structure.rb
@@ -85,7 +85,7 @@ class TestCoreStructure < Minitest::Test
       end
     end
 
-    assert_match(/Cannot specify both type and block/, error.message)
+    assert_match(/cannot specify both type and block/, error.message)
   end
 
   def test_attribute_with_default_value

--- a/test/test_type_coercions.rb
+++ b/test/test_type_coercions.rb
@@ -152,10 +152,12 @@ class TestTypeCoercions < Minitest::Test
   def test_invalid_object_type_raises_error
     invalid_object = Object.new
 
-    assert_raises(ArgumentError) do
+    error = assert_raises(ArgumentError) do
       Structure.new do
         attribute(:value, invalid_object)
       end
     end
+
+    assert_match(/cannot specify.*as type for :value/, error.message)
   end
 end


### PR DESCRIPTION
## Summary

Standardizes all error messages to use lowercase for consistency with Ruby conventions and improves type error messages to include attribute names for easier debugging.

## Changes

**Error Message Standardization:**
- `"Cannot specify both type and block for :name"` → `"cannot specify both type and block for :name"`
- `"Cannot specify X as type"` → `"cannot specify X as type for :attr"`

**Implementation:**
- Changed error messages in Builder and Types to lowercase
- Added exception handling in `Builder#coercions` to catch and re-raise `ArgumentError` with attribute context
- Updated tests to match new error format

## Before/After

**Before:**
```ruby
Structure.new { attribute(:value, Object.new) }
# ArgumentError: Cannot specify #<Object:0x...> as type
```

**After:**
```ruby
Structure.new { attribute(:value, Object.new) }
# ArgumentError: cannot specify #<Object:0x...> as type for :value
```

Now developers immediately know which attribute has the invalid type!

## Testing

- All 139 tests pass
- Updated test assertions to verify lowercase messages
- Added assertion to verify attribute name is included in type errors

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)